### PR TITLE
fix(core): inertia_rank OOB, warp assert, and fix broken tests

### DIFF
--- a/genesis-core/src/config/test_blueprints.rs
+++ b/genesis-core/src/config/test_blueprints.rs
@@ -30,7 +30,7 @@ fn test_blueprints_parse_full() {
         gsop_depression = 3
         prune_threshold = 20
         ltm_slot_count = 100
-        inertia_curve = [200, 190, 180, 170, 160, 150, 140, 130, 120, 110, 100, 90, 80, 70, 60, 50]
+        inertia_curve = [200, 190, 180, 170, 160, 150, 140, 130, 120, 110, 100, 90, 80, 70, 60]
     "#;
 
     let bp = BlueprintsConfig::parse(toml).unwrap();
@@ -44,7 +44,7 @@ fn test_blueprints_parse_full() {
     assert_eq!(nt.prune_threshold, 20);
     assert_eq!(nt.ltm_slot_count, 100);
     assert_eq!(nt.inertia_curve[0], 200);
-    assert_eq!(nt.inertia_curve[15], 50);
+    assert_eq!(nt.inertia_curve[14], 60);
     assert!((nt.sprouting_weight_sum() - 1.0).abs() < f32::EPSILON);
 }
 
@@ -80,7 +80,7 @@ fn test_blueprints_parse_minimal_with_defaults() {
     assert_eq!(nt.prune_threshold, 15);
     assert_eq!(nt.ltm_slot_count, 80); // default
     assert_eq!(nt.inertia_curve[0], 128); // default
-    assert_eq!(nt.inertia_curve[15], 8); // default
+    assert_eq!(nt.inertia_curve[14], 16); // default
 }
 
 #[test]

--- a/genesis-core/src/config/test_config.rs
+++ b/genesis-core/src/config/test_config.rs
@@ -23,7 +23,6 @@ fn test_default_values() {
     // Проверяем дефолты
     assert_eq!(cfg.simulation.segment_length_voxels, 5);
     assert_eq!(cfg.simulation.axon_growth_max_steps, 2000);
-    assert_eq!(cfg.simulation.night_interval_ticks, 0);
 }
 
 #[test]

--- a/genesis-core/src/config/test_instance.rs
+++ b/genesis-core/src/config/test_instance.rs
@@ -18,6 +18,8 @@ fn test_parse_instance_config() {
         [neighbors]
         x_minus = "127.0.0.1:8000"
         y_plus = "Self"
+		
+		[settings]
     "#;
 
     let config = InstanceConfig::parse(toml_str).expect("Failed to parse");

--- a/genesis-core/src/config/test_io.rs
+++ b/genesis-core/src/config/test_io.rs
@@ -9,6 +9,7 @@ fn test_io_parse_basic() {
         target_type = "L4_Stellate"
         width = 64
         height = 64
+		stride = 1
         
         [[input]]
         name = "audio_spectrogram"
@@ -16,6 +17,7 @@ fn test_io_parse_basic() {
         target_type = "ALL"
         width = 128
         height = 16
+		stride = 1
     "#;
 
     let io = IoConfig::parse(toml).unwrap();
@@ -45,6 +47,7 @@ fn test_io_parse_with_outputs() {
         target_type = "L5_Pyramidal"
         width = 8
         height = 8
+		stride = 1
         
         [[output]]
         name = "motor_leg"
@@ -52,6 +55,7 @@ fn test_io_parse_with_outputs() {
         target_type = "ALL"
         width = 4
         height = 4
+		stride = 1
     "#;
 
     let io = IoConfig::parse(toml).unwrap();

--- a/genesis-core/src/layout.rs
+++ b/genesis-core/src/layout.rs
@@ -204,7 +204,7 @@ impl ShardStateSoA {
     /// - `padded_n`: кол-во нейронов (кратно 32).
     /// - `total_axons`: общее кол-во аксонов (локальные + ghost + виртуальные).
     pub fn new(padded_n: usize, total_axons: usize) -> Self {
-        debug_assert!(padded_n % 32 == 0, "padded_n must be warp-aligned (multiple of 32)");
+        assert!(padded_n % 32 == 0, "padded_n must be warp-aligned (multiple of 32)");
         
         Self {
             padded_n,
@@ -224,7 +224,8 @@ impl ShardStateSoA {
     /// Вычисляет плоский индекс для Coalesced Access на GPU
     #[inline(always)]
     pub fn columnar_idx(padded_n: usize, neuron_idx: usize, slot: usize) -> usize {
-        debug_assert!(neuron_idx < padded_n && slot < MAX_DENDRITES);
+        assert!(neuron_idx < padded_n && slot < MAX_DENDRITES,
+    "columnar_idx: neuron_idx={neuron_idx} >= padded_n={padded_n} or slot={slot} >= {MAX_DENDRITES}");
         slot * padded_n + neuron_idx
     }
 }

--- a/genesis-core/src/physics.rs
+++ b/genesis-core/src/physics.rs
@@ -133,7 +133,7 @@ pub const fn update_homeostasis(
 #[inline(always)]
 pub const fn inertia_rank(abs_weight: i32) -> usize {
     let rank = (abs_weight >> 11) as usize;
-    if rank > 15 { 15 } else { rank }
+    if rank > 14 { 14 } else { rank }
 }
 
 /// Вычисляет новый вес синапса с учетом GSOP, инерции и слот-декея.
@@ -335,8 +335,8 @@ mod tests {
         assert_eq!(inertia_rank(2048), 1);
         assert_eq!(inertia_rank(4095), 1);
         assert_eq!(inertia_rank(4096), 2);
-        assert_eq!(inertia_rank(32767), 15);
-        assert_eq!(inertia_rank(40000), 15); // clamped
+        assert_eq!(inertia_rank(32767), 14);
+		assert_eq!(inertia_rank(40000), 14);
     }
 
     #[test]

--- a/genesis-core/src/test_gsop_math.rs
+++ b/genesis-core/src/test_gsop_math.rs
@@ -15,7 +15,7 @@ fn emulate_gsop_math(
     let rank = (abs_w >> 11) as usize;
     
     // Защита от выхода за пределы (хотя clamp ниже не даст весу стать > 32767)
-    let rank_safe = rank.min(15);
+    let rank_safe = rank.min(14);
     let inertia = p.inertia_curve[rank_safe] as u16;
 
     // 6. Branchless GSOP Math
@@ -59,7 +59,7 @@ fn test_neuron() -> NeuronType {
     nt.ltm_slot_count = 80;
     nt.slot_decay_ltm = 120; // ~0.93x
     nt.slot_decay_wm = 64;   // ~0.50x
-    nt.inertia_curve = [128, 120, 112, 104, 96, 88, 80, 72, 64, 56, 48, 40, 32, 24, 16, 8];
+    nt.inertia_curve = [128, 120, 112, 104, 96, 88, 80, 72, 64, 56, 48, 40, 32, 24, 16];
     nt
 }
 
@@ -123,10 +123,10 @@ fn test_gsop_sign_preserved() {
 fn test_inertia_rank_boundaries() {
     let mut nt = test_neuron();
     // Custom inertia, чтобы точно видеть ранги
-    nt.inertia_curve = [0; 16];
-    nt.inertia_curve[0] = 64;  // rank 0
-    nt.inertia_curve[1] = 128; // rank 1
-    nt.inertia_curve[15] = 255; // rank 15
+    nt.inertia_curve = [0; 15];
+	nt.inertia_curve[0] = 64;
+	nt.inertia_curve[1] = 128;
+	nt.inertia_curve[14] = 255;
 
     // rank 0: 0..2047
     let w0 = emulate_gsop_math(2000, true, 0, &nt);


### PR DESCRIPTION
## Problem

### 1. inertia_rank() returns out-of-bounds index
inertia_rank() clamped to 15, but all inertia_curve arrays are [_; 15]
(max valid index = 14). At max weight, rank = 15 → index out of bounds.

Several tests used 16-element array literals for [_; 15] fields
and accessed index 15 (runtime panic).

### 2. Warp alignment check stripped in release
ShardStateSoA::new() used debug_assert! for warp alignment.
Per Spec §01, this is a Project Invariant — must not be stripped
in --release builds, where it silently corrupts VRAM layout.

### 3. Three tests failed to compile / panicked
- test_config.rs: referenced non-existent SimulationParams.night_interval_ticks
- test_io.rs: missing required field 'stride' in test fixtures
- test_instance.rs: missing required section [settings] in test fixture

## Fix
- Clamp inertia_rank() to 14
- debug_assert! → assert! for warp alignment
- Fix all broken test fixtures

## Result
All 93 tests pass.